### PR TITLE
Add/Fix parsing of component names with punctuation

### DIFF
--- a/scripts/statuspage.coffee
+++ b/scripts/statuspage.coffee
@@ -98,7 +98,7 @@ module.exports = (robot) ->
        else
          msg.send "Systems currently in a degraded state: #{("#{component.name} (#{component.status.replace(/_/g, " ")})" for component in components).join(", ")}"
 
-  robot.respond /status ((?!(incidents|open|update|resolve|create))([-.\w] ?)+)\?$/i, (msg) ->
+  robot.respond /status ((?!(incidents|open|update|resolve|create))(\S ?)+)\?$/i, (msg) ->
     msg.http("#{baseUrl}/components.json")
      .headers(authHeader)
      .get() (err, res, body) ->
@@ -110,7 +110,7 @@ module.exports = (robot) ->
        else
          msg.send "Status of #{msg.match[1]}: #{components[0].status.replace(/_/g, " ")}"
        
-  robot.respond /status (([-.\w] ?)+) (major( outage)?|degraded( performance)?|partial( outage)?|operational)/i, (msg) ->
+  robot.respond /status ((\S ?)+) (major( outage)?|degraded( performance)?|partial( outage)?|operational)/i, (msg) ->
     componentName = msg.match[1]
     status = msg.match[3]
     status = componentStatuses[status] || status


### PR DESCRIPTION
First and foremost, thanks much for this script, works great and really saves time during incidents :)

We also use component names with punctuation though (i.e. dashes and dots in addition to the already supported underscore) and presumably quite some users might do this (the StatusPage.io API supports it just fine) - I've adjusted the respective regular expressions from `((\w ?)+)` to `(([-.\w] ?)+)` accordingly now.
- while there are obviously more special characters still, I guess those three cover most typical naming conventions, thus should be sufficient until more specific needs arise
